### PR TITLE
Add ability to filter by attribute namespace_id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,3 +69,28 @@ pub mod types {
         }
     }
 }
+
+pub mod dsl {
+    use types::AbacAttributeSqlType;
+    use diesel::expression::{grouped::Grouped, Expression};
+
+    mod predicates {
+        use diesel::pg::Pg;
+        use diesel::sql_types::{Uuid};
+
+        diesel_postfix_operator!(NamespaceId, ".namespace_id", Uuid, backend: Pg);
+    }
+
+    use self::predicates::*;
+
+    pub trait AbacAttributeExpressionMethods: Expression<SqlType = AbacAttributeSqlType> {
+        fn namespace_id(self) -> NamespaceId<Grouped<Self>>
+            where
+                Self: Sized,
+        {
+            NamespaceId::new(Grouped(self))
+        }
+    }
+
+    impl<T: Expression<SqlType = AbacAttributeSqlType>> AbacAttributeExpressionMethods for T {}
+}


### PR DESCRIPTION
This PR provides support for queries like
```sql
select * 
from abac_subject
where (inbound).namespace_id = UUID;
```

```rust
extern crate abac;
extern crate diesel;
extern crate uuid;

use abac::dsl::*;
use abac::schema::abac_subject;
use diesel::prelude::*;

fn main() {
    let query = abac_subject::table
        .filter(abac_subject::inbound.namespace_id().eq(uuid::Uuid::new_v4()));

    let debug = diesel::debug_query::<diesel::pg::Pg, _>(&query);
    println!("{:?}", debug);
}
```